### PR TITLE
Fix: validator 추가

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,10 @@ _.load = function (middleware) {
 
 _.initRouter = function () {
 	this.routeList = walk({
-		dir: this.options.dir
+		dir: this.options.dir,
+		blacklist: function(fullPath) {
+			return fullPath.match(/.joi.js$/);
+		}
 	});
 };
 
@@ -65,23 +68,18 @@ _.setRouter = function () {
 			}
 		});
 
-		const joiFileName = `_${path.basename(filePath).split('.')[0]}.joi.js`;
-		let pathURL = filePath.split('/');
-		pathURL.pop(); // remove origin.js
-		pathURL = pathURL.join('/');
-		const joiURL = `${pathURL}/${joiFileName}`; // add _origin.joi.js
-
+		const joiFilePath = filePath.replace(/.js$/, '.joi.js');
 		if (that.middleware.hasOwnProperty('inputValidator')) {
-			if (fs.existsSync(joiURL)) {
-				args.push(that.middleware['inputValidator'](require(joiURL).inputValidator.options));
+			if (fs.existsSync(joiFilePath)) {
+				args.push(that.middleware['inputValidator'](require(joiFilePath).inputValidator.options));
 			}
 		}
 
 		args.push(target.main);
 
 		if (that.middleware.hasOwnProperty('outputValidator')) {
-			if (fs.existsSync(joiURL)) {
-				args.push(that.middleware['outputValidator'](require(joiURL).outputValidator.options));
+			if (fs.existsSync(joiFilePath)) {
+				args.push(that.middleware['outputValidator'](require(joiFilePath).outputValidator.options));
 			}
 		}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,12 +5,13 @@ var express = require('express'),
 	defaultize = swintHelper.defaultize,
 	walk = swintHelper.walk,
 	path = require('path');
+const fs = require('fs');
 
-module.exports = function(options) {
+module.exports = function (options) {
 	defaultize({
 		dir: path.join(path.dirname(require.main.filename), 'router')
 	}, options);
-	
+
 	this.options = options;
 
 	this.routeList = null;
@@ -19,24 +20,24 @@ module.exports = function(options) {
 
 var _ = module.exports.prototype;
 
-_.load = function(middleware) {
+_.load = function (middleware) {
 	this.middleware = middleware;
 	this.initRouter();
 	this.setRouter();
 };
 
-_.initRouter = function() {
+_.initRouter = function () {
 	this.routeList = walk({
 		dir: this.options.dir
 	});
 };
 
-_.setRouter = function() {
+_.setRouter = function () {
 	var that = this;
 
 	this.expRouter = express.Router();
 
-	this.routeList.forEach(function(filePath) {
+	this.routeList.forEach(function (filePath) {
 		var target = defaultize({
 				info: {
 					url: '/swint',
@@ -44,7 +45,7 @@ _.setRouter = function() {
 				},
 				preMiddleware: [],
 				postMiddleware: [],
-				main: function(req, res, next) {
+				main: function (req, res, next) {
 					next();
 				}
 			}, require(filePath)),
@@ -52,7 +53,7 @@ _.setRouter = function() {
 
 		args.push(target.info.url);
 
-		target.preMiddleware.forEach(function(m) {
+		target.preMiddleware.forEach(function (m) {
 			if (typeof m === 'object') {
 				args.push(that.middleware[m.name](m.options));
 			} else {
@@ -69,22 +70,22 @@ _.setRouter = function() {
 		pathURL.pop(); // remove origin.js
 		pathURL = pathURL.join('/');
 		const joiURL = `${pathURL}/${joiFileName}`; // add _origin.joi.js
-		
-		if(that.middleware.hasOwnProperty('inputValidator')){
-			if(fs.existsSync(joiURL)){
+
+		if (that.middleware.hasOwnProperty('inputValidator')) {
+			if (fs.existsSync(joiURL)) {
 				args.push(that.middleware['inputValidator'](require(joiURL).inputValidator.options));
 			}
 		}
 
 		args.push(target.main);
 
-		if(that.middleware.hasOwnProperty('outputValidator')){
-			if(fs.existsSync(joiURL)){
+		if (that.middleware.hasOwnProperty('outputValidator')) {
+			if (fs.existsSync(joiURL)) {
 				args.push(that.middleware['outputValidator'](require(joiURL).outputValidator.options));
 			}
 		}
 
-		target.postMiddleware.forEach(function(m) {
+		target.postMiddleware.forEach(function (m) {
 			if (typeof m === 'object') {
 				args.push(that.middleware[m.name](m.options));
 			} else {
@@ -96,7 +97,7 @@ _.setRouter = function() {
 			}
 		});
 
-		args.push(function(req, res, next) {
+		args.push(function (req, res, next) {
 			req.not404 = true;
 			next();
 		});

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,25 @@ _.setRouter = function() {
 			}
 		});
 
+		const joiFileName = `_${path.basename(filePath).split('.')[0]}.joi.js`;
+		let pathURL = filePath.split('/');
+		pathURL.pop(); // remove origin.js
+		pathURL = pathURL.join('/');
+		const joiURL = `${pathURL}/${joiFileName}`; // add _origin.joi.js
+		
+		if(that.middleware.hasOwnProperty('inputValidator')){
+			if(fs.existsSync(joiURL)){
+				args.push(that.middleware['inputValidator'](require(joiURL).inputValidator.options));
+			}
+		}
+
 		args.push(target.main);
+
+		if(that.middleware.hasOwnProperty('outputValidator')){
+			if(fs.existsSync(joiURL)){
+				args.push(that.middleware['outputValidator'](require(joiURL).outputValidator.options));
+			}
+		}
 
 		target.postMiddleware.forEach(function(m) {
 			if (typeof m === 'object') {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "swint-helper": "1.2.8"
   },
   "devDependencies": {
-    "mocha": "4.0.1",
     "eslint": "4.12.1",
+    "joi": "14.3.1",
+    "mocha": "4.0.1",
     "request": "2.83.0",
     "swint-middleware": "1.1.10"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 var assert = require('assert'),
 	request = require('request'),
 	express = require('express'),
@@ -10,8 +12,8 @@ var assert = require('assert'),
 
 // global.swintVar.printLevel = 5;
 
-describe('Plain router', function() {
-	before(function() {
+describe('Plain router', function () {
+	before(function () {
 		var app = express(),
 			myRouter = new swintRouter({
 				dir: path.join(__dirname, '../test_case/router')
@@ -23,7 +25,8 @@ describe('Plain router', function() {
 
 		try {
 			fs.mkdirSync(path.join(os.tmpdir(), 'swint-router'));
-		} catch(e) { }
+		} catch (e) {
+		}
 
 		myRouter.load(myMiddleware);
 
@@ -32,10 +35,10 @@ describe('Plain router', function() {
 		server.listen(8080);
 	});
 
-	it('test request', function(done) {
+	it('test request', function (done) {
 		request.get({
 			url: 'http://localhost:8080/test_case'
-		}, function(err, resp, body) {
+		}, function (err, resp, body) {
 			assert.equal(resp.headers['x-pre-middleware1'], 'middleware1');
 			assert.equal(resp.headers['x-pre-middleware2'], 'middlewareOptionString');
 			assert.equal(
@@ -46,10 +49,34 @@ describe('Plain router', function() {
 		});
 	});
 
-	after(function() {
+	it('test validation success', function (done) {
+		request.get({
+			url: 'http://localhost:8080/validationTest',
+			qs: {input: JSON.stringify({'name': 'knowre'})},
+		}, function (err, resp, body) {
+			assert.equal(JSON.parse(body).data.hello, 'world');
+			done();
+		})
+	})
+
+	it('test validation input fail', function (done) {
+		request.get({
+			url: 'http://localhost:8080/validationTest',
+			qs: {input: JSON.stringify({'name': 1})},
+		}, function (err, resp, body) {
+			assert.equal(JSON.parse(body).ERROR, 'child "name" fails because ["name" must be a string]');
+			done();
+		})
+	})
+
+
+	after(function () {
 		try {
 			fs.unlinkSync(path.join(os.tmpdir(), 'swint-router/post-middleware.txt'));
 			fs.rmdirSync(path.join(os.tmpdir(), 'swint-router'));
-		} catch(e) { }
+		} catch (e) {
+		}
 	});
 });
+
+/* eslint-disable */

--- a/test_case/middleware/inputValidator.js
+++ b/test_case/middleware/inputValidator.js
@@ -1,0 +1,39 @@
+const Joi = require('joi');
+
+module.exports = (options = {}) => {
+	const validator = new InputValidator(options);
+	return function (req, res, next) {
+		validator.validate(req, res, next);
+	};
+};
+
+class InputValidator {
+	constructor(options) {
+		this.input_schema = options.input_schema instanceof Object ? options.input_schema : {};
+		this.params_schema = options.params_schema instanceof Object ? options.params_schema : {};
+	}
+
+	validate(req, res, next) {
+		try {
+			this.validator(req);
+			req.validation_schema = {
+				input: this.input_schema
+			};
+			next();
+		} catch (err) {
+			res.status(400).json({ERROR: err});
+		}
+	}
+
+	validator(req) {
+		req.input = JSON.parse(req.query['input']);
+		let result = Joi.validate(req.input, this.input_schema);
+		if (result.error !== null) {
+			throw result.error.message;
+		}
+		result = Joi.validate(req.params, this.params_schema);
+		if (result.error !== null) {
+			throw result.error.message;
+		}
+	}
+}

--- a/test_case/middleware/outputValidator.js
+++ b/test_case/middleware/outputValidator.js
@@ -1,0 +1,37 @@
+const Joi = require('joi');
+
+module.exports = (options = {}) => {
+	const validator = new OutputValidator(options);
+
+	return (req, res, next) => {
+		validator.validate(req, res, next);
+	};
+};
+
+class OutputValidator {
+	constructor(options) {
+		this.output_schema = options.output_schema instanceof Object ? options.output_schema : {};
+	}
+
+	validate(req, res, next) {
+		const data = req.output.data;
+
+		try {
+			this.validator(data);
+			req.validation_schema = req.validation_schema || {};
+			req.validation_schema.out = this.output_schema;
+			next();
+		} catch (err) {
+			//main route already sent 처리 필요.
+			console.log('OUTVAL ERROR OCCUR!!'); //eslint-disable-line
+		}
+	}
+
+	validator(data) {
+		const result = Joi.validate(data, this.output_schema);
+		if (result.error !== null) {
+			throw result.error.message;
+		}
+		return result;
+	}
+}

--- a/test_case/router/validationTest.joi.js
+++ b/test_case/router/validationTest.joi.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Joi = require('joi');
+
+exports.inputValidator = {
+	options: {
+		input_schema: Joi.object().keys({
+			name: Joi.string().required()
+		}),
+		params_schema: {}
+	}
+};
+
+exports.outputValidator = {
+	options: {
+		output_schema: Joi.object().keys({
+			hello: Joi.string().required()
+		}),
+	}
+};

--- a/test_case/router/validationTest.js
+++ b/test_case/router/validationTest.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.info = {
+	url: '/validationTest',
+	method: 'get'
+};
+
+exports.preMiddleware = [];
+
+exports.postMiddleware = [];
+
+exports.main = function (req, res, next) {
+	req.output = {};
+	req.output.data = {hello: 'world'};
+	res.status(200).json(req.output);
+	next();
+};


### PR DESCRIPTION
Joi 를 사용한 API input 과 output 을 validation 을 위한 선작업으로 swint route 를 건드리게 되었습니다.
파일을 따로 가져가서 import 하는 형태로 작성하는게 어떨까 싶었고, 
route 미들웨어가 빌드되는 과정에서 joi.js 파일을 읽어 들어와야 해서, 어쩔수 없이 이곳을 건드렸습니다.

또한 볼수 있는 이득으로는...라우터내 preMiddleware = [] 에 항상 validation 미들웨어 작성을 줄일수 있습니다.

getUserRoute.js 의 라우팅이 있다면
getUserRoute.joi.js 를 만들고, 내부에 validation 스키마를 작성. 하여 main 로직 앞뒤로 밀어넣습니다.